### PR TITLE
구글 계정 회원가입 로직 수정

### DIFF
--- a/src/routes/로그인 & 회원가입/SignUp.tsx
+++ b/src/routes/로그인 & 회원가입/SignUp.tsx
@@ -212,19 +212,23 @@ const SignUp = () => {
 
     //이메일 유효성 검사를 통과했을때, (형식에 맞는 경우 true 리턴)
     if (emailValidationCheck.test(inputEmail)) {
-      //@gmail.com일때
-      if (inputEmail.includes('@gmail.com')) {
-        setValidationCheck((prevState) => {
-          return { ...prevState, emailCheck: 'gmail', emailCheckBoolean: false };
-        });
-      } else { //일반 이메일일때
-        //이메일 중복체크 백엔드 통신
-        //string인 inputEmail을 json형태의 객체로 변환
-        let jsonObj = { 'email': inputEmail };
-        //변환한 json 객체로 이메일 중복체크
-        CheckEmailDuplicated(jsonObj);
-        // dispatch(setEmail(inputEmail))
-      }
+      // TODO gmail 간편 로그인을 없앴기 때문에 아래 코드는 실행되어선 안된다.
+      // //@gmail.com일때
+      // if (inputEmail.includes('@gmail.com')) {
+      //   setValidationCheck((prevState) => {
+      //     return { ...prevState, emailCheck: 'gmail', emailCheckBoolean: false };
+      //   });
+      // }
+      // else { //일반 이메일일때
+      //   //이메일 중복체크 백엔드 통신
+      //   //string인 inputEmail을 json형태의 객체로 변환
+      //   let jsonObj = { 'email': inputEmail };
+      //   //변환한 json 객체로 이메일 중복체크
+      //   CheckEmailDuplicated(jsonObj);
+      //   // dispatch(setEmail(inputEmail))
+      // }
+      let jsonObj = { 'email': inputEmail };
+      CheckEmailDuplicated(jsonObj);
     } else //이메일 유효성 검사 실패했을때
     {
       setValidationCheck((prevState) => {
@@ -394,10 +398,10 @@ const SignUp = () => {
           ||
           (validationCheck.emailCheck === 'valid' &&
             <Message validCheck={validationCheck.emailCheckBoolean} content={'✔ 사용 가능한 이메일입니다.'} />)
-          ||
-          (validationCheck.emailCheck === 'gmail' &&
-            <Message validCheck={validationCheck.emailCheckBoolean}
-                     content={'❌ gmail 계정은 Google 로그인을 이용해주세요.'} />)
+          //||
+          // (validationCheck.emailCheck === 'gmail' &&
+          //   <Message validCheck={validationCheck.emailCheckBoolean}
+          //            content={'❌ gmail 계정은 Google 로그인을 이용해주세요.'} />)
           ||
           (validationCheck.emailCheck === 'invalid' &&
             <Message validCheck={validationCheck.emailCheckBoolean} content={'❌ 유효하지 않은 이메일입니다.'} />)


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- OAuth2 제거로 인한 기존 회원가입 로직 수정
     - 기존 방식에서는 Gmail 가입의 경우 유효하지 않은 요청으로 처리 (간편 로그인 권장)
     - 현재 방식에서는 타 도메인과 구분 없이 가입 가능
